### PR TITLE
Add PHP as supported file extension

### DIFF
--- a/src/semantic_code_search/embed.py
+++ b/src/semantic_code_search/embed.py
@@ -26,6 +26,7 @@ def _supported_file_extensions():
         '.kt': 'kotlin',
         '.kts': 'kotlin',
         '.ktm': 'kotlin',
+        '.php': 'php',
     }
 
 


### PR DESCRIPTION
There is already a PHP Lexer set up, but the file extension is not in the list of supported file extensions