### PR TITLE
Update setup.py: fix pip / pipx editable install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     python_requires='>=3.8',
     url='https://github.com/sturdy-dev/semantic-code-search',
     package_dir={
-        "semantic_code_search": "src/semantic_code_search"
+        "": "src"
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This fixes `ModuleNotFound` error when the package is installed in editable mode e.g.: `pip install -e .` See https://stackoverflow.com/a/66710618 for more information.